### PR TITLE
Unnecessary use of regular expression.

### DIFF
--- a/CreditCardFraudDetection.php
+++ b/CreditCardFraudDetection.php
@@ -74,7 +74,7 @@ class CreditCardFraudDetection extends HTTPBase {
 
   function filter_field($key, $value) {
     if ($key == 'emailMD5'){
-      if (preg_match('/\@/', $value)){
+      if (strpos($value, '@') !== false){
 	return md5(strtolower($value));
       }
     } else if ($key == 'usernameMD5' || $key == 'passwordMD5') {


### PR DESCRIPTION
The use of `preg_match()`  (formerly `ereg()`) in `CreditCardFraudDetection->filter_field()` is unnecessary to check the existence of a single character and more computationally expensive than using the native `strpos()` function.
