### PR TITLE
Instantiate $buf before loop to eliminate undefined variable warning

### DIFF
--- a/src/HTTPBase.php
+++ b/src/HTTPBase.php
@@ -300,6 +300,7 @@ abstract class HTTPBase
                       . $query;
 
                 fputs($fp, $post);
+                $buf = '';
                 while (!feof($fp)) {
                     $buf .= fgets($fp, 128);
                 }


### PR DESCRIPTION
As the title suggests: simply declare $buf before the while loop in order to avoid an undefined variable warning. Some configurations (like my local dev box) may be set to die on such warnings.
