### PR TITLE
Added php < 5.3 backwards compatibility

### DIFF
--- a/src/HTTPBase.php
+++ b/src/HTTPBase.php
@@ -165,7 +165,9 @@ abstract class HTTPBase
             }
             $this->queries[$key] = urlencode($this->filter_field($key, $val));
         }
-        $this->queries['clientAPI'] = static::API_VERSION;
+        $this->queries['clientAPI'] = constant(
+            get_class($this) . '::API_VERSION'
+        );
     }
 
     /**


### PR DESCRIPTION
"static" can not be used like that in environments using earlier versions than 5.3
