### PR TITLE
Security issue - possible MITM attack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
             "homepage": "http://www.maxmind.com/"
         }
     ],
+    "require": {
+        "kdyby/curl-ca-bundle": "~1.0"
+    },
     "autoload": {
         "files": [
             "src/HTTPBase.php",

--- a/src/HTTPBase.php
+++ b/src/HTTPBase.php
@@ -256,6 +256,7 @@ abstract class HTTPBase
             curl_setopt($ch, CURLOPT_URL, $url);
             curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+            \Kdyby\CurlCaBundle\CertificateHelper::setCurlCaInfo($ch);
 
             // This option lets you store the result in a string.
             curl_setopt($ch, CURLOPT_POST, 1);


### PR DESCRIPTION
Hello,
I noticed that for curl connection is disabled option CURLOPT_SSL_VERIFYHOST. It could make a possibility of man-in-the-man attack because curl does not verify server's certificate.

I have enabled this option and created dependency on Kdyby\CaCurl which provides CA certificate from mozilla.org with autoupdate command.
