### PR TITLE
UTF8 encode the value before saving to an array.

### DIFF
--- a/src/HTTPBase.php
+++ b/src/HTTPBase.php
@@ -203,7 +203,7 @@ abstract class HTTPBase
      * @param string $server
      * @return bool
      */
-    public function querySingleServer($server)
+    public function querySingleServer($server, $utf8Encode = false)
     {
         // Check if we using the Secure HTTPS proctol.
         $scheme = $this->isSecure ? 'https://' : 'http://';
@@ -354,7 +354,7 @@ abstract class HTTPBase
                 echo " output {$key} = {$value}\n";
             }
 
-            $this->outputstr[$key] = utf8_encode($value);
+            $this->outputstr[$key] = $utf8Encode ? utf8_encode($value) : $value;
         }
 
         // One other way to do it.


### PR DESCRIPTION
Without this people might have problem doing `json_encode` (return false) or saving result to Doctrine.
I found this problem when city name contain "Reykjavík" (IP: 89.160.161.129)
